### PR TITLE
Add Deactivate method to ControlledItems

### DIFF
--- a/include/controlleditem.hpp
+++ b/include/controlleditem.hpp
@@ -16,6 +16,8 @@ namespace Signalbox {
 
     virtual void Activate() {};
 
+    virtual void Deactivate() {};
+
     virtual std::string getTypeString() const = 0;
   private:
     ItemId id;

--- a/include/controlleditemmanager.hpp
+++ b/include/controlleditemmanager.hpp
@@ -21,6 +21,12 @@ namespace Signalbox {
       signalHeadFactory(this->pinManager.get()),
       trackCircuitMonitorFactory(this->pinManager.get(), this->rtcClient.get()),
       items() {}
+
+    ~ControlledItemManager() {
+      for( auto it=this->items.begin(); it!=this->items.end(); it++ ) {
+	(*it).second->Deactivate();
+      }
+    }
     
     virtual ControlledItemFactory* GetSignalHeadFactory() override;
 

--- a/include/trackcircuitmonitor.hpp
+++ b/include/trackcircuitmonitor.hpp
@@ -12,13 +12,15 @@ namespace Signalbox {
   class TrackCircuitMonitor : public ControlledItem {
   public:
     ~TrackCircuitMonitor() {
+      this->Deactivate();
       if( this->t.joinable() ) {
-	this->done = true;
 	this->t.join();
       }
     }
 
     virtual void Activate() override;
+
+    virtual void Deactivate() override;
     
     bool Get() const;
 

--- a/src/trackcircuitmonitor.cpp
+++ b/src/trackcircuitmonitor.cpp
@@ -6,6 +6,10 @@ namespace Signalbox {
     this->t = std::thread(&TrackCircuitMonitor::Run, this);
   }
 
+  void TrackCircuitMonitor::Deactivate() {
+    this->done = true;
+  }
+
   void TrackCircuitMonitor::Run() {
     bool lastState = this->Get();
     this->rtc->SendTrackCircuitNotification( this->getId(), lastState );


### PR DESCRIPTION
Add a Deactivate method to ControlledItems
This is called by the destructor of the ControlledItemManager, so that all items can start shutting themselves down before their own destructors are called (sequentially)
Note that a ControlledItem must not rely on Deactivate being called exactly once; it may occur zero or multiple times