### PR TITLE
Add limited I2C device support

### DIFF
--- a/app/consolepinmanager.hpp
+++ b/app/consolepinmanager.hpp
@@ -13,6 +13,10 @@ namespace Signalbox {
     ConsolePinManager() :
       MapPinManager(),
       pwmChannels() {}
+
+    virtual void Initialise( const std::vector<I2CDeviceData>& i2cDevices ) override {
+      throw std::runtime_error(__PRETTY_FUNCTION__);
+    }
     
     virtual PWMChannel* CreatePWMChannel(const DeviceRequestData& data) override;
   protected:

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -41,6 +41,9 @@ int main(int ac, char* av[]) {
     Signalbox::RailTrafficControlData rtcData;
     cr.ReadRailTrafficControl( rtcData );
 
+    Signalbox::I2CBusData i2cBusData;
+    cr.ReadI2CData( i2cBusData );
+
     std::cout << "Read config file" << std::endl;
     
     // -----
@@ -52,6 +55,8 @@ int main(int ac, char* av[]) {
     Signalbox::PinManagerFactory* pmf = dest->GetPinManagerFactory();
     Signalbox::ControlledItemManager cim(pmf, rtcClient);
 
+    cim.Initialise( i2cBusData );
+    
     auto nPopulate = cim.PopulateItems( configItems );
     std::cout << "Populated " << nPopulate << " items" << std::endl;
 

--- a/include/controlleditemmanager.hpp
+++ b/include/controlleditemmanager.hpp
@@ -11,6 +11,8 @@
 #include "trackcircuitmonitorfactory.hpp"
 #include "servoturnoutmotorfactory.hpp"
 
+#include "i2cbusdata.hpp"
+
 #include "railtrafficcontrolclient.hpp"
 
 namespace Signalbox {
@@ -28,6 +30,10 @@ namespace Signalbox {
       for( auto it=this->items.begin(); it!=this->items.end(); it++ ) {
 	(*it).second->Deactivate();
       }
+    }
+
+    void Initialise( I2CBusData& i2cBus ) {
+      this->pinManager->Initialise( i2cBus.devices );
     }
     
     virtual ControlledItemFactory* GetSignalHeadFactory() override;

--- a/include/hardwareprovider.hpp
+++ b/include/hardwareprovider.hpp
@@ -5,6 +5,8 @@
 namespace Signalbox {
   class HardwareProvider {
   public:
-    virtual void Register(HardwareProviderRegistrar registrar) = 0;
+    virtual ~HardwareProvider() {}
+    
+    virtual void Register(HardwareProviderRegistrar& registrar) = 0;
   };
 }

--- a/include/hardwareprovider.hpp
+++ b/include/hardwareprovider.hpp
@@ -7,6 +7,6 @@ namespace Signalbox {
   public:
     virtual ~HardwareProvider() {}
     
-    virtual void Register(HardwareProviderRegistrar& registrar) = 0;
+    virtual void Register(HardwareProviderRegistrar* registrar) = 0;
   };
 }

--- a/include/i2cdevice.hpp
+++ b/include/i2cdevice.hpp
@@ -6,7 +6,7 @@
 #include "hardwareprovider.hpp"
 
 namespace Signalbox {
-  class I2CDevice : HardwareProvider {
+  class I2CDevice : public HardwareProvider {
   public:
     I2CDevice( const std::string deviceName,
 	       const unsigned int bus,

--- a/include/i2cdevice.hpp
+++ b/include/i2cdevice.hpp
@@ -1,17 +1,26 @@
 #pragma once
 
+#include <string>
+#include <map>
+
 #include "hardwareprovider.hpp"
 
 namespace Signalbox {
   class I2CDevice : HardwareProvider {
   public:
-    I2CDevice( const unsigned int bus,
+    I2CDevice( const std::string deviceName,
+	       const unsigned int bus,
 	       const unsigned int address ) :
+      name(deviceName),
       i2cBus(bus),
       i2cAddress(address) {}
+
+    virtual ~I2CDevice() {}
+
+    virtual void Initialise( const std::map<std::string,std::string>& settings )= 0;
     
-  protected:
-    unsigned int i2cBus;
-    unsigned int i2cAddress;
+    const std::string name;
+    const unsigned int i2cBus;
+    const unsigned int i2cAddress;
   };
 }

--- a/include/i2cdevicefactory.hpp
+++ b/include/i2cdevicefactory.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+#include "i2cdevicedata.hpp"
+#include "i2cdevice.hpp"
+
+namespace Signalbox {
+  class I2CDeviceFactory {
+  public:
+    virtual ~I2CDeviceFactory() {}
+
+    virtual std::unique_ptr<I2CDevice> CreateDevice(const I2CDeviceData& data) = 0;
+  };
+}

--- a/include/mocki2cdevicefactory.hpp
+++ b/include/mocki2cdevicefactory.hpp
@@ -1,12 +1,23 @@
 #pragma once
 
+#include <set>
+#include <utility>
+
 #include "i2cdevicefactory.hpp"
 
 namespace Signalbox {
   class MockI2CDeviceFactory : public I2CDeviceFactory {
   public:
+    MockI2CDeviceFactory() :
+      I2CDeviceFactory(),
+      deviceNames(),
+      deviceBusAddresses() {}
+    
     virtual ~MockI2CDeviceFactory() {}
 
     virtual std::unique_ptr<I2CDevice> CreateDevice(const I2CDeviceData& data) override;
+  private:
+    std::set<std::string> deviceNames;
+    std::set<std::pair<unsigned int,unsigned int>> deviceBusAddresses;
   };
 }

--- a/include/mocki2cdevicefactory.hpp
+++ b/include/mocki2cdevicefactory.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "i2cdevicefactory.hpp"
+
+namespace Signalbox {
+  class MockI2CDeviceFactory : public I2CDeviceFactory {
+  public:
+    virtual ~MockI2CDeviceFactory() {}
+
+    virtual std::unique_ptr<I2CDevice> CreateDevice(const I2CDeviceData& data) override;
+  };
+}

--- a/include/mockpca9685.hpp
+++ b/include/mockpca9685.hpp
@@ -20,7 +20,7 @@ namespace Signalbox {
     virtual PWMChannel* GetPWMChannel( const std::string channelId,
 				       const std::map<std::string,std::string> settings ) override;
 
-    virtual void Register(HardwareProviderRegistrar& registrar) override;
+    virtual void Register(HardwareProviderRegistrar* registrar) override;
     
     double referenceClock;
     double pwmFrequency;

--- a/include/mockpca9685.hpp
+++ b/include/mockpca9685.hpp
@@ -2,6 +2,7 @@
 
 #include "pwmchannelprovider.hpp"
 #include "i2cdevice.hpp"
+#include "mockpwmchannel.hpp"
 
 namespace Signalbox {
   class MockPCA9685 : public I2CDevice, public PWMChannelProvider {
@@ -11,7 +12,8 @@ namespace Signalbox {
 	         const unsigned int address ) :
       I2CDevice(deviceName,bus,address),
       referenceClock(-1),
-      pwmFrequency(-1) {}
+      pwmFrequency(-1),
+      assignedChannels() {}
 
     virtual void Initialise( const std::map<std::string,std::string>& settings ) override;
 
@@ -22,5 +24,7 @@ namespace Signalbox {
     
     double referenceClock;
     double pwmFrequency;
+
+    std::map<unsigned int,std::unique_ptr<MockPWMChannel>> assignedChannels;
   };
 }

--- a/include/mockpca9685.hpp
+++ b/include/mockpca9685.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "pwmchannelprovider.hpp"
 #include "i2cdevice.hpp"
 #include "mockpwmchannel.hpp"

--- a/include/mockpca9685.hpp
+++ b/include/mockpca9685.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "pwmchannelprovider.hpp"
+#include "i2cdevice.hpp"
+
+namespace Signalbox {
+  class MockPCA9685 : public I2CDevice, public PWMChannelProvider {
+  public:
+    MockPCA9685( const std::string deviceName,
+	         const unsigned int bus,
+	         const unsigned int address ) :
+      I2CDevice(deviceName,bus,address),
+      referenceClock(-1),
+      pwmFrequency(-1) {}
+
+    virtual void Initialise( const std::map<std::string,std::string>& settings ) override;
+
+    virtual PWMChannel* GetPWMChannel( const std::string channelId,
+				       const std::map<std::string,std::string> settings ) override;
+
+    virtual void Register(HardwareProviderRegistrar& registrar) override;
+    
+    double referenceClock;
+    double pwmFrequency;
+  };
+}

--- a/include/mockpinmanager.hpp
+++ b/include/mockpinmanager.hpp
@@ -3,16 +3,23 @@
 #include "pinmanager.hpp"
 #include "mappinmanager.hpp"
 
+#include "hardwareproviderregistrar.hpp"
+
 #include "mockdigitaloutputpin.hpp"
 #include "mockdigitalinputpin.hpp"
 #include "mockpwmchannel.hpp"
+
+#include "i2cdevice.hpp"
+#include "i2cdevicedata.hpp"
 
 namespace Signalbox {
   class MockPinManager : public MapPinManager<std::string,MockDigitalInputPin,MockDigitalOutputPin> {
   public:
     MockPinManager() :
       MapPinManager(),
-      pwmChannels() {}
+      pwmChannels(),
+      devices(),
+      hpr() {}
 
     virtual void Initialise( const std::vector<I2CDeviceData>& i2cDevices ) override;
     
@@ -21,6 +28,10 @@ namespace Signalbox {
     MockDigitalInputPin* FetchMockDigitalInputPin(const std::string pinId) const;
 
     MockPWMChannel* FetchMockPWMChannel(const DeviceRequestData& data) const;
+
+    size_t I2CDeviceCount() const {
+      return this->devices.size();
+    }
     
     size_t DigitalOutputPinCount() const {
       return this->getOutputPinCount();
@@ -41,6 +52,10 @@ namespace Signalbox {
 
   private:
     std::map<std::string,std::unique_ptr<MockPWMChannel>> pwmChannels;
+
+    std::vector<std::unique_ptr<I2CDevice>> devices;
+
+    HardwareProviderRegistrar hpr;
     
     std::string getKey(const DeviceRequestData& data) const {
       return data.controller + data.controllerData;

--- a/include/mockpinmanager.hpp
+++ b/include/mockpinmanager.hpp
@@ -13,6 +13,8 @@ namespace Signalbox {
     MockPinManager() :
       MapPinManager(),
       pwmChannels() {}
+
+    virtual void Initialise( const std::vector<I2CDeviceData>& i2cDevices ) override;
     
     MockDigitalOutputPin* FetchMockDigitalOutputPin(const std::string pinId) const;
     

--- a/include/pca9685pwmchannel.hpp
+++ b/include/pca9685pwmchannel.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "pwmchannel.hpp"
+
+namespace Signalbox {
+  class PCA9685PWMChannel : public PWMChannel {
+  public:
+    PCA9685PWMChannel(const int pi,
+		      const int devHandle,
+		      const unsigned int stopReg) :
+      piId(pi),
+      deviceHandle(devHandle),
+      stopRegister(stopReg) {}
+
+    virtual void Set(const unsigned int value ) override;
+
+    virtual unsigned int Get() const override;
+
+    const int piId;
+    const int deviceHandle;
+    const unsigned int stopRegister;
+  };
+}

--- a/include/pigpiodchecker.hpp
+++ b/include/pigpiodchecker.hpp
@@ -1,0 +1,10 @@
+#include <iostream>
+
+#define PIGPIOD_SAFE_CALL( call ) { \
+    const int err = call;	    \
+    if( err < 0 ) {				    \
+      std::cerr << "PiGPIOd error on line " << __LINE__ \
+		<< " of file " __FILE__			\
+		<< std::endl				\
+		<< "Returned value was " << err << std::endl;	\
+      exit(1); } }

--- a/include/pigpiodpca9685.hpp
+++ b/include/pigpiodpca9685.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+
+#include "pwmchannelprovider.hpp"
+#include "i2cdevice.hpp"
+#include "pca9685pwmchannel.hpp"
+
+namespace Signalbox {
+  class PiGPIOdPCA9685 : public I2CDevice, public PWMChannelProvider {
+    PiGPIOdPCA9685( const std::string deviceName,
+		    const unsigned int bus,
+		    const unsigned int address ) :
+      I2CDevice(deviceName,bus,address),
+      piId(-1),
+      deviceHandle(-1),
+      referenceClock(-1),
+      pwmFrequency(-1),
+      assignedChannels() {}
+
+    virtual ~PiGPIOdPCA9685();
+    
+    virtual void Initialise( const std::map<std::string,std::string>& settings ) override;
+
+    virtual PWMChannel* GetPWMChannel( const std::string channelId,
+				       const std::map<std::string,std::string> settings ) override;
+
+    virtual void Register(HardwareProviderRegistrar* registrar) override;
+
+    int piId;
+    int deviceHandle;
+    double referenceClock;
+    double pwmFrequency;
+
+    std::map<unsigned int,std::unique_ptr<PCA9685PWMChannel>> assignedChannels;
+
+    unsigned char StartRegister(const unsigned char channel) const;
+    unsigned char StopRegister(const unsigned char channel) const;
+
+    void CheckChannel(const unsigned char channel) const;
+  private:
+    const int registerMODE1 = 0x00;
+    const int registerPRESCALE = 0xfe;
+    const unsigned char channels = 16;
+  };
+}

--- a/include/pigpiodpca9685.hpp
+++ b/include/pigpiodpca9685.hpp
@@ -8,6 +8,7 @@
 
 namespace Signalbox {
   class PiGPIOdPCA9685 : public I2CDevice, public PWMChannelProvider {
+  public:
     PiGPIOdPCA9685( const std::string deviceName,
 		    const unsigned int bus,
 		    const unsigned int address ) :

--- a/include/pigpiodpinmanager.hpp
+++ b/include/pigpiodpinmanager.hpp
@@ -7,6 +7,11 @@
 #include "pinmanager.hpp"
 #include "mappinmanager.hpp"
 
+#include "i2cdevice.hpp"
+#include "i2cdevicedata.hpp"
+
+#include "hardwareproviderregistrar.hpp"
+
 #include "pigpioddigitaloutputpin.hpp"
 #include "pigpioddigitalinputpin.hpp"
 
@@ -25,9 +30,7 @@ namespace Signalbox {
       return this->piId;
     }
 
-    virtual void Initialise(const std::vector<I2CDeviceData>& i2cDevices) {
-      throw std::runtime_error(__PRETTY_FUNCTION__);
-    }
+    virtual void Initialise(const std::vector<I2CDeviceData>& i2cDevices) override;
     
     virtual PWMChannel* CreatePWMChannel(const DeviceRequestData& data) override;
     
@@ -47,5 +50,7 @@ namespace Signalbox {
     static void callBackDispatch(int pi, unsigned int user_gpio, unsigned int level, uint32_t tick);
     
     int piId;
+    std::vector<std::unique_ptr<I2CDevice>> devices;
+    HardwareProviderRegistrar hpr;
   };
 }

--- a/include/pigpiodpinmanager.hpp
+++ b/include/pigpiodpinmanager.hpp
@@ -25,6 +25,10 @@ namespace Signalbox {
       return this->piId;
     }
 
+    virtual void Initialise(const std::vector<I2CDeviceData>& i2cDevices) {
+      throw std::runtime_error(__PRETTY_FUNCTION__);
+    }
+    
     virtual PWMChannel* CreatePWMChannel(const DeviceRequestData& data) override;
     
     // Remove copy constructor and operator=

--- a/include/pinmanager.hpp
+++ b/include/pinmanager.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
+#include "i2cdevicedata.hpp"
 
 #include "digitaloutputpin.hpp"
 #include "digitalinputpin.hpp"
@@ -15,6 +17,8 @@ namespace Signalbox {
   public:
     virtual ~PinManager() {}
 
+    virtual void Initialise( const std::vector<I2CDeviceData>& i2cDevices ) = 0;
+    
     virtual DigitalOutputPin* CreateDigitalOutputPin(const std::string pinId) = 0;
 
     virtual DigitalInputPin* CreateDigitalInputPin(const DigitalInputPinData& data) = 0;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ LIST(APPEND srcs mockpca9685.cpp)
 LIST(APPEND srcs mockrailtrafficcontrolclient.cpp)
 
 IF( pigpio_FOUND )
+  LIST(APPEND srcs pca9685pwmchannel.cpp)
+  LIST(APPEND srcs pigpiodpca9685.cpp)
   LIST(APPEND srcs pigpioddigitaloutputpin.cpp)
   LIST(APPEND srcs pigpioddigitalinputpin.cpp)
   LIST(APPEND srcs pigpiodpinmanager.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,11 +27,14 @@ LIST(APPEND srcs trackcircuitmonitorfactory.cpp)
 LIST(APPEND srcs servoturnoutmotorfactory.cpp)
 
 LIST(APPEND srcs controlleditemmanager.cpp)
+LIST(APPEND srcs hardwareproviderregistrar.cpp)
 
 LIST(APPEND srcs mockpinmanager.cpp)
 LIST(APPEND srcs mockdigitaloutputpin.cpp)
 LIST(APPEND srcs mockdigitalinputpin.cpp)
 LIST(APPEND srcs mockpwmchannel.cpp)
+
+LIST(APPEND srcs mockpca9685.cpp)
 
 LIST(APPEND srcs mockrailtrafficcontrolclient.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ LIST(APPEND srcs mockdigitaloutputpin.cpp)
 LIST(APPEND srcs mockdigitalinputpin.cpp)
 LIST(APPEND srcs mockpwmchannel.cpp)
 
+LIST(APPEND srcs mocki2cdevicefactory.cpp)
 LIST(APPEND srcs mockpca9685.cpp)
 
 LIST(APPEND srcs mockrailtrafficcontrolclient.cpp)

--- a/src/hardwareproviderregistrar.cpp
+++ b/src/hardwareproviderregistrar.cpp
@@ -6,22 +6,24 @@
 namespace Signalbox {
   void HardwareProviderRegistrar::RegisterPWMChannelProvider( const std::string providerName,
 							      PWMChannelProvider* provider ) {
-    std::stringstream msg;
-    msg << __FUNCTION__
-	<< " unable to register "
-	<< providerName
-	<< " due to lack of implementation"
-	<< std::endl;
-    throw std::runtime_error(msg.str());
+    if( this->pwmChannelProviders.count(providerName) != 0 ) {
+      std::stringstream msg;
+      msg << "PWMChannelProvider '"
+	  << providerName
+	  << "' already registered";
+      throw std::out_of_range(msg.str());
+    }
+    this->pwmChannelProviders[providerName] = provider;
   }
 
   PWMChannelProvider* HardwareProviderRegistrar::GetPWMChannelProvider( const std::string providerName ) const {
-     std::stringstream msg;
-     msg << __FUNCTION__
-	<< " unable to get PWMChannel from "
-	<< providerName
-	<< " due to lack of implementation"
-	<< std::endl;
-    throw std::runtime_error(msg.str());
+    if( this->pwmChannelProviders.count(providerName) != 1 ) {
+      std::stringstream msg;
+      msg << "PWMChannelProvider '"
+	  << providerName
+	  << "' not found";
+      throw std::out_of_range(msg.str());
+    }
+    return this->pwmChannelProviders.at(providerName);
   }
 }

--- a/src/hardwareproviderregistrar.cpp
+++ b/src/hardwareproviderregistrar.cpp
@@ -1,0 +1,27 @@
+#include <sstream>
+#include <stdexcept>
+
+#include "hardwareproviderregistrar.hpp"
+
+namespace Signalbox {
+  void HardwareProviderRegistrar::RegisterPWMChannelProvider( const std::string providerName,
+							      PWMChannelProvider* provider ) {
+    std::stringstream msg;
+    msg << __FUNCTION__
+	<< " unable to register "
+	<< providerName
+	<< " due to lack of implementation"
+	<< std::endl;
+    throw std::runtime_error(msg.str());
+  }
+
+  PWMChannelProvider* HardwareProviderRegistrar::GetPWMChannelProvider( const std::string providerName ) const {
+     std::stringstream msg;
+     msg << __FUNCTION__
+	<< " unable to get PWMChannel from "
+	<< providerName
+	<< " due to lack of implementation"
+	<< std::endl;
+    throw std::runtime_error(msg.str());
+  }
+}

--- a/src/mocki2cdevicefactory.cpp
+++ b/src/mocki2cdevicefactory.cpp
@@ -3,12 +3,34 @@
 
 #include "mockpca9685.hpp"
 
+#include <iomanip>
+
 #include "mocki2cdevicefactory.hpp"
 
 namespace Signalbox {
   std::unique_ptr<I2CDevice> MockI2CDeviceFactory::CreateDevice(const I2CDeviceData& data) {
     std::unique_ptr<I2CDevice> result;
 
+    
+    if( this->deviceNames.count(data.name) != 0 ) {
+      std::stringstream msg;
+      msg << "Specified device name '"
+	  << data.name
+	  << "' already exists";
+      throw std::out_of_range(msg.str());
+    }
+
+    auto busAddress = std::make_pair(data.bus, data.address);
+    if( this->deviceBusAddresses.count(busAddress) != 0 ) {
+      std::stringstream msg;
+      msg << "Specified bus and address ["
+	  << busAddress.first
+	  << ", "
+	  << std::hex << std::showbase << busAddress.second
+	  << "] already assigned to a device";
+      throw std::out_of_range(msg.str());
+    }
+    
     if( data.kind == "pca9685" ) {
       result = std::unique_ptr<I2CDevice>(new MockPCA9685(data.name, data.bus, data.address));
     } else {
@@ -18,9 +40,10 @@ namespace Signalbox {
 	  << "' not recognised";
       throw std::out_of_range(msg.str());
     }
-
     result->Initialise(data.settings);
-    
+
+    this->deviceNames.insert(data.name);
+    this->deviceBusAddresses.insert(busAddress);
     return result;
   }
 }

--- a/src/mocki2cdevicefactory.cpp
+++ b/src/mocki2cdevicefactory.cpp
@@ -7,7 +7,17 @@
 
 namespace Signalbox {
   std::unique_ptr<I2CDevice> MockI2CDeviceFactory::CreateDevice(const I2CDeviceData& data) {
-    auto result = std::unique_ptr<MockPCA9685>(new MockPCA9685(data.name, data.bus, data.address));
+    std::unique_ptr<I2CDevice> result;
+
+    if( data.kind == "pca9685" ) {
+      result = std::unique_ptr<I2CDevice>(new MockPCA9685(data.name, data.bus, data.address));
+    } else {
+      std::stringstream msg;
+      msg << "Specified device kind '"
+	  << data.kind
+	  << "' not recognised";
+      throw std::out_of_range(msg.str());
+    }
 
     result->Initialise(data.settings);
     

--- a/src/mocki2cdevicefactory.cpp
+++ b/src/mocki2cdevicefactory.cpp
@@ -1,0 +1,16 @@
+#include <sstream>
+#include <stdexcept>
+
+#include "mockpca9685.hpp"
+
+#include "mocki2cdevicefactory.hpp"
+
+namespace Signalbox {
+  std::unique_ptr<I2CDevice> MockI2CDeviceFactory::CreateDevice(const I2CDeviceData& data) {
+    auto result = std::unique_ptr<MockPCA9685>(new MockPCA9685(data.name, data.bus, data.address));
+
+    result->Initialise(data.settings);
+    
+    return result;
+  }
+}

--- a/src/mockpca9685.cpp
+++ b/src/mockpca9685.cpp
@@ -5,10 +5,29 @@
 
 namespace Signalbox {
   void MockPCA9685::Initialise( const std::map<std::string,std::string>& settings ) {
-    std::stringstream msg;
-    msg << __PRETTY_FUNCTION__
-	<< " not implemented";
-    throw std::runtime_error(msg.str());
+    const std::string refClockSetting = "referenceClock";
+    const std::string pwmFreqSetting = "pwmFrequency";
+
+    if( settings.count(refClockSetting) != 1 ) {
+      std::stringstream msg;
+      msg << "Settings for MockPCA9685 did not contain " << refClockSetting;
+      throw std::out_of_range(msg.str());
+    }
+    if( settings.count(pwmFreqSetting) != 1 ) {
+      std::stringstream msg;
+      msg << "Settings for MockPCA9685 did not contain " << pwmFreqSetting;
+      throw std::out_of_range(msg.str());
+    }
+
+    this->referenceClock = std::stod(settings.at(refClockSetting));
+    this->pwmFrequency = std::stod(settings.at(pwmFreqSetting));
+
+    if( this->referenceClock <= 0 ) {
+      throw std::out_of_range("referenceClock must be positive"); 
+    }
+    if( this->pwmFrequency <= 0 ) {
+      throw std::out_of_range("pwmFrequency must be positive");
+    }
   }
 
   PWMChannel* MockPCA9685::GetPWMChannel( const std::string channelId,

--- a/src/mockpca9685.cpp
+++ b/src/mockpca9685.cpp
@@ -32,10 +32,27 @@ namespace Signalbox {
 
   PWMChannel* MockPCA9685::GetPWMChannel( const std::string channelId,
 					  const std::map<std::string,std::string> settings ) {
-    std::stringstream msg;
-    msg << __PRETTY_FUNCTION__
-	<< " not implemented";
-    throw std::runtime_error(msg.str());
+    if( settings.size() > 0 ) {
+      throw std::out_of_range("settings not supported in MockPCA9685::GetPWMChannel");
+    }
+    
+    const unsigned int channel = std::stoul(channelId);
+    if( channel >= 16 ) {
+      throw std::out_of_range("channelId must be in range [0,15]");
+    }
+
+    if( this->assignedChannels.count(channel) != 0 ) {
+      std::stringstream msg;
+      msg << "Channel " << channel << " is already assigned";
+      throw std::out_of_range(msg.str());
+    }
+
+    auto nxtChannel = std::unique_ptr<MockPWMChannel>( new MockPWMChannel );
+    nxtChannel->controller = this->name;
+    nxtChannel->controllerData = channelId;
+    this->assignedChannels[channel] = std::move(nxtChannel);
+
+    return this->assignedChannels[channel].get();
   }
 
   void MockPCA9685::Register(HardwareProviderRegistrar& registrar) {

--- a/src/mockpca9685.cpp
+++ b/src/mockpca9685.cpp
@@ -55,7 +55,7 @@ namespace Signalbox {
     return this->assignedChannels[channel].get();
   }
 
-  void MockPCA9685::Register(HardwareProviderRegistrar& registrar) {
-    registrar.RegisterPWMChannelProvider( this->name, this );
+  void MockPCA9685::Register(HardwareProviderRegistrar* registrar) {
+    registrar->RegisterPWMChannelProvider( this->name, this );
   }
 }

--- a/src/mockpca9685.cpp
+++ b/src/mockpca9685.cpp
@@ -1,0 +1,25 @@
+#include <sstream>
+#include <stdexcept>
+
+#include "mockpca9685.hpp"
+
+namespace Signalbox {
+  void MockPCA9685::Initialise( const std::map<std::string,std::string>& settings ) {
+    std::stringstream msg;
+    msg << __PRETTY_FUNCTION__
+	<< " not implemented";
+    throw std::runtime_error(msg.str());
+  }
+
+  PWMChannel* MockPCA9685::GetPWMChannel( const std::string channelId,
+					  const std::map<std::string,std::string> settings ) {
+    std::stringstream msg;
+    msg << __PRETTY_FUNCTION__
+	<< " not implemented";
+    throw std::runtime_error(msg.str());
+  }
+
+  void MockPCA9685::Register(HardwareProviderRegistrar& registrar) {
+    registrar.RegisterPWMChannelProvider( this->name, this );
+  }
+}

--- a/src/mockpinmanager.cpp
+++ b/src/mockpinmanager.cpp
@@ -5,6 +5,10 @@
 
 namespace Signalbox {
 
+  void MockPinManager::Initialise( const std::vector<I2CDeviceData>& i2cDevices ) {
+    throw std::runtime_error(__PRETTY_FUNCTION__);
+  }
+  
   MockDigitalOutputPin* MockPinManager::FetchMockDigitalOutputPin(const std::string pinId) const {
     return this->getOutputPin(pinId);
   }

--- a/src/mockpinmanager.cpp
+++ b/src/mockpinmanager.cpp
@@ -3,10 +3,22 @@
 
 #include "mockpinmanager.hpp"
 
+#include "mocki2cdevicefactory.hpp"
+
 namespace Signalbox {
 
   void MockPinManager::Initialise( const std::vector<I2CDeviceData>& i2cDevices ) {
-    throw std::runtime_error(__PRETTY_FUNCTION__);
+    MockI2CDeviceFactory devFactory;
+
+    for( auto it=i2cDevices.begin();
+	 it!=i2cDevices.end();
+	 ++it ) {
+      auto nxtDevice = devFactory.CreateDevice(*it);
+
+      nxtDevice->Register(&(this->hpr));
+
+      this->devices.push_back(std::move(nxtDevice));
+    }
   }
   
   MockDigitalOutputPin* MockPinManager::FetchMockDigitalOutputPin(const std::string pinId) const {

--- a/src/pca9685pwmchannel.cpp
+++ b/src/pca9685pwmchannel.cpp
@@ -1,0 +1,20 @@
+#include <stdexcept>
+#include <pigpiod_if2.h>
+
+#include "pigpiodchecker.hpp"
+
+#include "pca9685pwmchannel.hpp"
+
+namespace Signalbox {
+  void PCA9685PWMChannel::Set(const unsigned int value) {
+    if( value >= 4096 ) {
+      throw std::out_of_range("Must set value < 4096");
+    }
+    PIGPIOD_SAFE_CALL( i2c_write_word_data(this->piId, this->deviceHandle,
+					   this->stopRegister, value) );
+  }
+
+  unsigned int PCA9685PWMChannel::Get() const {
+    throw std::runtime_error(__PRETTY_FUNCTION__);
+  }
+}

--- a/src/pigpiodpca9685.cpp
+++ b/src/pigpiodpca9685.cpp
@@ -1,0 +1,134 @@
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <chrono>
+#include <iomanip>
+#include <cmath>
+
+#include <pigpiod_if2.h>
+
+#include "pigpiodchecker.hpp"
+
+#include "pigpiodpca9685.hpp"
+
+namespace Signalbox {
+  PiGPIOdPCA9685::~PiGPIOdPCA9685() {
+     i2c_close(this->piId, this->deviceHandle);
+  }
+
+  void PiGPIOdPCA9685::Initialise( const std::map<std::string,std::string>& settings ) {
+    const std::string refClockSetting = "referenceClock";
+    const std::string pwmFreqSetting = "pwmFrequency";
+
+    if( settings.count(refClockSetting) != 1 ) {
+      std::stringstream msg;
+      msg << "Settings for PiGPIOdPCA9685 did not contain " << refClockSetting;
+      throw std::out_of_range(msg.str());
+    }
+    if( settings.count(pwmFreqSetting) != 1 ) {
+      std::stringstream msg;
+      msg << "Settings for PiGPIOdPCA9685 did not contain " << pwmFreqSetting;
+      throw std::out_of_range(msg.str());
+    }
+
+    this->referenceClock = std::stod(settings.at(refClockSetting));
+    this->pwmFrequency = std::stod(settings.at(pwmFreqSetting));
+
+    if( this->referenceClock <= 0 ) {
+      throw std::out_of_range("referenceClock must be positive"); 
+    }
+    if( this->pwmFrequency <= 0 ) {
+      throw std::out_of_range("pwmFrequency must be positive");
+    }
+
+    // Start the chip
+    const int i2cFlags = 0; // Only allowed value
+
+    this->deviceHandle = i2c_open(this->piId, this->i2cBus, this->i2cAddress, i2cFlags);
+    if( this->deviceHandle < 0 ) {
+      std::cerr << "i2c_open returned: " << this->deviceHandle << std::endl;
+      exit(1);
+    }
+
+    // Configure the chip
+    const char enableValue = 0x20;
+    PIGPIOD_SAFE_CALL( i2c_write_byte_data(this->piId, this->deviceHandle,
+					   PiGPIOdPCA9685::registerMODE1, enableValue) );
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+    // Enable change of the prescale value
+    const char enablePrescaleValue = 0x10;
+    PIGPIOD_SAFE_CALL( i2c_write_byte_data(this->piId, this->deviceHandle,
+					   PiGPIOdPCA9685::registerMODE1,
+					   enablePrescaleValue) );
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    
+    // Calculate prescale from Equation (1) of datasheet
+    const unsigned char prescaleValue = round( referenceClock / 4096 / pwmFrequency ) - 1;
+    std::cout << "Calculated prescale = "
+	      << std::setbase(16)
+	      << (unsigned int)prescaleValue
+	      << std::endl;
+    if( prescaleValue < 3 ) {
+      throw std::invalid_argument("Calculated prescaleValue is less than 3");
+    }
+
+    // Set the prescale
+    PIGPIOD_SAFE_CALL( i2c_write_byte_data(this->piId, this->deviceHandle,
+					   PiGPIOdPCA9685::registerPRESCALE,
+					   prescaleValue) );
+
+    // Put the chip back into the right mode
+    PIGPIOD_SAFE_CALL( i2c_write_byte_data(this->piId, this->deviceHandle,
+					   PiGPIOdPCA9685::registerMODE1,
+					   enableValue) );
+    
+    // Set all 'start' registers to 0
+    for( unsigned char c=0; c < PiGPIOdPCA9685::channels; c++ ) {
+      const unsigned char startRegister = this->StartRegister(c);
+      PIGPIOD_SAFE_CALL( i2c_write_word_data(this->piId, this->deviceHandle,
+					     startRegister, 0 ) );
+    } 
+  }
+
+  unsigned char PiGPIOdPCA9685::StartRegister(const unsigned char channel) const {
+    this->CheckChannel(channel);
+    
+    return 0x06 + (channel*4);
+  }
+
+  unsigned char PiGPIOdPCA9685::StopRegister(const unsigned char channel) const {
+    this->CheckChannel(channel);
+
+    return 0x08 + (channel*4);
+  }
+
+  void PiGPIOdPCA9685::CheckChannel(const unsigned char channel) const {
+    if( channel >= PiGPIOdPCA9685::channels ) {
+      throw std::out_of_range("Only have 16 channels");
+    }
+  }
+
+  PWMChannel* PiGPIOdPCA9685::GetPWMChannel( const std::string channelId,
+					     const std::map<std::string,std::string> settings ) {
+    if( settings.size() > 0 ) {
+      throw std::out_of_range("settings not supported in PiGPIOdPCA9685::GetPWMChannel");
+    }
+    
+    const unsigned int channel = std::stoul(channelId);
+    if( channel >= PiGPIOdPCA9685::channels ) {
+      throw std::out_of_range("channelId must be in range [0,15]");
+    }
+
+    if( this->assignedChannels.count(channel) != 0 ) {
+      std::stringstream msg;
+      msg << "Channel " << channel << " is already assigned";
+      throw std::out_of_range(msg.str());
+    }
+
+    auto nxtChannel = std::unique_ptr<PCA9685PWMChannel>( new PCA9685PWMChannel(this->piId, this->deviceHandle, this->StopRegister(channel)) );
+    this->assignedChannels[channel] = std::move(nxtChannel);
+
+    return this->assignedChannels[channel].get();
+  }
+}

--- a/src/pigpiodpca9685.cpp
+++ b/src/pigpiodpca9685.cpp
@@ -131,4 +131,9 @@ namespace Signalbox {
 
     return this->assignedChannels[channel].get();
   }
+
+  void PiGPIOdPCA9685::Register(HardwareProviderRegistrar* registrar) {
+    registrar->RegisterPWMChannelProvider( this->name, this );
+  }
+
 }

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -20,6 +20,7 @@ LIST(APPEND srcs trackcircuitmonitorfactorytest.cpp)
 LIST(APPEND srcs servoturnoutmotorfactorytest.cpp)
 
 LIST(APPEND srcs controlleditemmanagertest.cpp)
+LIST(APPEND srcs hardwareproviderregistrartest.cpp)
 
 LIST(APPEND srcs mockpinmanagertest.cpp)
 LIST(APPEND srcs mockdigitalinputpintest.cpp)

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -25,6 +25,8 @@ LIST(APPEND srcs mockpinmanagertest.cpp)
 LIST(APPEND srcs mockdigitalinputpintest.cpp)
 LIST(APPEND srcs mockrailtrafficcontrolclienttest.cpp)
 
+LIST(APPEND srcs mockpca9685test.cpp)
+
 IF( pigpio_FOUND )
   LIST(APPEND srcs pigpiodpinmanagertest.cpp)
 ENDIF()

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -27,6 +27,7 @@ LIST(APPEND srcs mockdigitalinputpintest.cpp)
 LIST(APPEND srcs mockrailtrafficcontrolclienttest.cpp)
 
 LIST(APPEND srcs mockpca9685test.cpp)
+LIST(APPEND srcs mocki2cdevicefactorytest.cpp)
 
 IF( pigpio_FOUND )
   LIST(APPEND srcs pigpiodpinmanagertest.cpp)

--- a/tst/hardwareproviderregistrartest.cpp
+++ b/tst/hardwareproviderregistrartest.cpp
@@ -1,0 +1,71 @@
+#include <boost/test/unit_test.hpp>
+
+#include "mockpca9685.hpp"
+#include "exceptionmessagecheck.hpp"
+
+#include "hardwareproviderregistrar.hpp"
+
+BOOST_AUTO_TEST_SUITE( HardwareProviderRegistrar )
+
+BOOST_AUTO_TEST_SUITE( PWMChannelProvider )
+
+BOOST_AUTO_TEST_CASE( RegisterAndFetch )
+{
+  Signalbox::HardwareProviderRegistrar hpr;
+
+  const std::string name = "mymock";
+  const unsigned int bus = 1;
+  const unsigned int address = 0x40;
+  Signalbox::MockPCA9685 device(name, bus, address);
+
+  hpr.RegisterPWMChannelProvider( name, &device );
+
+  auto fetched = hpr.GetPWMChannelProvider( name );
+
+  BOOST_CHECK_EQUAL( fetched, &device );
+}
+
+BOOST_AUTO_TEST_CASE( NoPWMChannelProvider )
+{
+  Signalbox::HardwareProviderRegistrar hpr;
+  
+  std::string msg("PWMChannelProvider 'none' not found");
+
+  // Check when empty
+  BOOST_CHECK_EXCEPTION( hpr.GetPWMChannelProvider("none"),
+			 std::out_of_range,
+			 GetExceptionMessageChecker<std::out_of_range>(msg) );
+
+  const std::string name = "mymock";
+  const unsigned int bus = 1;
+  const unsigned int address = 0x40;
+  Signalbox::MockPCA9685 device(name, bus, address);
+
+  hpr.RegisterPWMChannelProvider( name, &device );
+  // Check that we still get exception on non-existent provider
+  BOOST_CHECK_EXCEPTION( hpr.GetPWMChannelProvider("none"),
+			 std::out_of_range,
+			 GetExceptionMessageChecker<std::out_of_range>(msg) );
+}
+
+BOOST_AUTO_TEST_CASE( NameUsedTwice )
+{
+  Signalbox::HardwareProviderRegistrar hpr;
+  
+  const std::string name = "mymock";
+  const unsigned int bus = 1;
+  const unsigned int address = 0x40;
+  Signalbox::MockPCA9685 device1(name, bus, address);
+  Signalbox::MockPCA9685 device2(name, bus, address+2);
+
+  hpr.RegisterPWMChannelProvider( name, &device1 );
+
+  std::string msg("PWMChannelProvider 'mymock' already registered");
+  BOOST_CHECK_EXCEPTION( hpr.RegisterPWMChannelProvider( name, &device2 );,
+			 std::out_of_range,
+			 GetExceptionMessageChecker<std::out_of_range>(msg) );
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mocki2cdevicefactorytest.cpp
+++ b/tst/mocki2cdevicefactorytest.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "mockpca9685.hpp"
+#include "exceptionmessagecheck.hpp"
 
 #include "mocki2cdevicefactory.hpp"
 
@@ -34,7 +35,18 @@ BOOST_AUTO_TEST_CASE( CreateMockPCA9685 )
 
 BOOST_AUTO_TEST_CASE( CreateUnknownDevice )
 {
-  BOOST_FAIL("Test not implemented");
+  Signalbox::MockI2CDeviceFactory df;
+  
+  Signalbox::I2CDeviceData deviceData;
+  deviceData.kind = "noSuchKind";
+  deviceData.bus = 0;
+  deviceData.address = 0x40;
+  deviceData.name = "SC01";
+
+  std::string msg("Specified device kind 'noSuchKind' not recognised");
+  BOOST_CHECK_EXCEPTION( df.CreateDevice(deviceData),
+			 std::out_of_range,
+			 GetExceptionMessageChecker<std::out_of_range>(msg) );
 }
 
 BOOST_AUTO_TEST_CASE( CreateDuplicateName )

--- a/tst/mocki2cdevicefactorytest.cpp
+++ b/tst/mocki2cdevicefactorytest.cpp
@@ -1,0 +1,50 @@
+#include <boost/test/unit_test.hpp>
+
+#include "mockpca9685.hpp"
+
+#include "mocki2cdevicefactory.hpp"
+
+BOOST_AUTO_TEST_SUITE( MockI2CDeviceFactory )
+
+BOOST_AUTO_TEST_CASE( CreateMockPCA9685 )
+{
+  Signalbox::MockI2CDeviceFactory df;
+  
+  Signalbox::I2CDeviceData deviceData;
+  deviceData.kind = "pca9685";
+  deviceData.bus = 0;
+  deviceData.address = 0x40;
+  deviceData.name = "SC01";
+  deviceData.settings["referenceClock"] = "25e6";
+  deviceData.settings["pwmFrequency"] = "50";
+
+  auto device = df.CreateDevice(deviceData);
+  BOOST_REQUIRE(device);
+
+  BOOST_CHECK_EQUAL( deviceData.name, device->name );
+  BOOST_CHECK_EQUAL( deviceData.bus, device->i2cBus );
+  BOOST_CHECK_EQUAL( deviceData.address, device->i2cAddress );
+
+  auto mockpca9685 = dynamic_cast<Signalbox::MockPCA9685*>(device.get());
+  BOOST_REQUIRE(mockpca9685);
+
+  BOOST_CHECK_EQUAL( 25e6, mockpca9685->referenceClock );
+  BOOST_CHECK_EQUAL( 50, mockpca9685->pwmFrequency );
+}
+
+BOOST_AUTO_TEST_CASE( CreateUnknownDevice )
+{
+  BOOST_FAIL("Test not implemented");
+}
+
+BOOST_AUTO_TEST_CASE( CreateDuplicateName )
+{
+  BOOST_FAIL("Test not implemented");
+}
+
+BOOST_AUTO_TEST_CASE( CreateDuplicateBusAndAddress )
+{
+  BOOST_FAIL("Test not implemented");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mocki2cdevicefactorytest.cpp
+++ b/tst/mocki2cdevicefactorytest.cpp
@@ -51,12 +51,60 @@ BOOST_AUTO_TEST_CASE( CreateUnknownDevice )
 
 BOOST_AUTO_TEST_CASE( CreateDuplicateName )
 {
-  BOOST_FAIL("Test not implemented");
+  Signalbox::MockI2CDeviceFactory df;
+  
+  Signalbox::I2CDeviceData deviceData;
+  deviceData.kind = "pca9685";
+  deviceData.bus = 0;
+  deviceData.address = 0x40;
+  deviceData.name = "SC01";
+  deviceData.settings["referenceClock"] = "25e6";
+  deviceData.settings["pwmFrequency"] = "50";
+
+  auto device = df.CreateDevice(deviceData);
+  BOOST_REQUIRE(device);
+
+  Signalbox::I2CDeviceData deviceData2;
+  deviceData2.kind = "pca9685";
+  deviceData2.bus = 1;
+  deviceData2.address = 0x40;
+  deviceData2.name = "SC01";
+  deviceData2.settings["referenceClock"] = "25e6";
+  deviceData2.settings["pwmFrequency"] = "50";
+
+  std::string msg("Specified device name 'SC01' already exists");
+  BOOST_CHECK_EXCEPTION( df.CreateDevice(deviceData2),
+			 std::out_of_range,
+			 GetExceptionMessageChecker<std::out_of_range>(msg) );
 }
 
 BOOST_AUTO_TEST_CASE( CreateDuplicateBusAndAddress )
 {
-  BOOST_FAIL("Test not implemented");
+  Signalbox::MockI2CDeviceFactory df;
+  
+  Signalbox::I2CDeviceData deviceData;
+  deviceData.kind = "pca9685";
+  deviceData.bus = 0;
+  deviceData.address = 0x40;
+  deviceData.name = "SC01";
+  deviceData.settings["referenceClock"] = "25e6";
+  deviceData.settings["pwmFrequency"] = "50";
+
+  auto device = df.CreateDevice(deviceData);
+  BOOST_REQUIRE(device);
+
+  Signalbox::I2CDeviceData deviceData2;
+  deviceData2.kind = "pca9685";
+  deviceData2.bus = 0;
+  deviceData2.address = 0x40;
+  deviceData2.name = "SC02";
+  deviceData2.settings["referenceClock"] = "25e6";
+  deviceData2.settings["pwmFrequency"] = "50";
+
+  std::string msg("Specified bus and address [0, 0x40] already assigned to a device");
+  BOOST_CHECK_EXCEPTION( df.CreateDevice(deviceData2),
+			 std::out_of_range,
+			 GetExceptionMessageChecker<std::out_of_range>(msg) );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mockpca9685test.cpp
+++ b/tst/mockpca9685test.cpp
@@ -1,0 +1,28 @@
+#include <boost/test/unit_test.hpp>
+
+#include "mockpca9685.hpp"
+
+BOOST_AUTO_TEST_SUITE( MockPCA9685 )
+
+BOOST_AUTO_TEST_CASE( ConstructorAndInitialise )
+{
+  const std::string name = "mymock";
+  const unsigned int bus = 1;
+  const unsigned int address = 0x40;
+  Signalbox::MockPCA9685 device(name, bus, address);
+
+  BOOST_CHECK_EQUAL( name, device.name );
+  BOOST_CHECK_EQUAL( bus, device.i2cBus );
+  BOOST_CHECK_EQUAL( address, device.i2cAddress );
+
+  std::map<std::string,std::string> settings;
+  settings["referenceClock"] = "25e6";
+  settings["pwmFrequency"] = "50";
+
+  device.Initialise(settings);
+
+  BOOST_CHECK_EQUAL( 25e6, device.referenceClock );
+  BOOST_CHECK_EQUAL( 50, device.pwmFrequency );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mockpca9685test.cpp
+++ b/tst/mockpca9685test.cpp
@@ -23,6 +23,38 @@ BOOST_AUTO_TEST_CASE( ConstructorAndInitialise )
 
   BOOST_CHECK_EQUAL( 25e6, device.referenceClock );
   BOOST_CHECK_EQUAL( 50, device.pwmFrequency );
+  BOOST_CHECK_EQUAL( 0, device.assignedChannels.size() );
+}
+
+BOOST_AUTO_TEST_CASE( GetPWMChannel )
+{
+  const std::string name = "mymock";
+  const unsigned int bus = 1;
+  const unsigned int address = 0x40;
+  Signalbox::MockPCA9685 device(name, bus, address);
+  
+  std::map<std::string,std::string> settings;
+  settings["referenceClock"] = "25e6";
+  settings["pwmFrequency"] = "50";
+
+  device.Initialise(settings);
+
+  // Now the actual work
+  const std::string pwmChannelId = "00";
+  std::map<std::string,std::string> pwmSettings;
+
+  auto pwmChannel = device.GetPWMChannel(pwmChannelId, pwmSettings);
+  BOOST_REQUIRE(pwmChannel);
+
+  auto mpc = dynamic_cast<Signalbox::MockPWMChannel*>(pwmChannel);
+  BOOST_REQUIRE(mpc);
+
+  BOOST_CHECK_EQUAL( 1, device.assignedChannels.size() );
+  BOOST_CHECK_EQUAL( 1, device.assignedChannels.count(0) );
+  BOOST_CHECK_EQUAL( device.assignedChannels.at(0).get(), mpc );
+
+  BOOST_CHECK_EQUAL( mpc->controller, name );
+  BOOST_CHECK_EQUAL( mpc->controllerData, pwmChannelId );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mockpca9685test.cpp
+++ b/tst/mockpca9685test.cpp
@@ -1,5 +1,7 @@
 #include <boost/test/unit_test.hpp>
 
+#include "hardwareproviderregistrar.hpp"
+
 #include "mockpca9685.hpp"
 
 BOOST_AUTO_TEST_SUITE( MockPCA9685 )
@@ -55,6 +57,21 @@ BOOST_AUTO_TEST_CASE( GetPWMChannel )
 
   BOOST_CHECK_EQUAL( mpc->controller, name );
   BOOST_CHECK_EQUAL( mpc->controllerData, pwmChannelId );
+}
+
+BOOST_AUTO_TEST_CASE( RegisterWithRegistrar )
+{
+  const std::string name = "mymock";
+  const unsigned int bus = 1;
+  const unsigned int address = 0x40;
+  Signalbox::MockPCA9685 device(name, bus, address);
+
+  Signalbox::HardwareProviderRegistrar hpr;
+
+  device.Register(&hpr);
+
+  auto pcp = hpr.GetPWMChannelProvider(name);
+  BOOST_CHECK_EQUAL( pcp, &device );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tst/mockpinmanagertest.cpp
+++ b/tst/mockpinmanagertest.cpp
@@ -148,10 +148,35 @@ BOOST_AUTO_TEST_CASE( DuplicateCreateInputPin )
 			 GetExceptionMessageChecker<std::runtime_error>(msg) );
 }
 
+BOOST_AUTO_TEST_CASE( CreateMockPCA9685 )
+{
+  Signalbox::MockPinManager pm;
+
+  BOOST_CHECK_EQUAL( 0, pm.I2CDeviceCount() );
+
+  Signalbox::I2CDeviceData deviceData;
+  deviceData.kind = "pca9685";
+  deviceData.bus = 0;
+  deviceData.address = 0x40;
+  deviceData.name = "SC01";
+  deviceData.settings["referenceClock"] = "25e6";
+  deviceData.settings["pwmFrequency"] = "50";
+
+  std::vector<Signalbox::I2CDeviceData> deviceDataList;
+  deviceDataList.push_back(deviceData);
+
+  pm.Initialise(deviceDataList);
+
+  BOOST_CHECK_EQUAL( 1, pm.I2CDeviceCount() );
+  
+}
+
 BOOST_AUTO_TEST_CASE( CreatePWMChannel )
 {
   Signalbox::MockPinManager pm;
 
+  BOOST_FAIL("Need to update now that we have I2C");
+  
   Signalbox::DeviceRequestData data;
   data.controller = "sc01";
   data.controllerData = "01";
@@ -178,6 +203,7 @@ BOOST_AUTO_TEST_CASE( CreatePWMChannel )
 BOOST_AUTO_TEST_CASE( CreateTwoPWMChannels )
 {
   Signalbox::MockPinManager pm;
+  BOOST_FAIL("Need to update now that we have I2C");
 
   Signalbox::DeviceRequestData data1;
   data1.controller = "sc01";
@@ -200,6 +226,7 @@ BOOST_AUTO_TEST_CASE( CreateTwoPWMChannels )
 BOOST_AUTO_TEST_CASE( DuplicatePWMChannel )
 {
   Signalbox::MockPinManager pm;
+  BOOST_FAIL("Need to update now that we have I2C");
   
   Signalbox::DeviceRequestData data;
   data.controller = "sc01";


### PR DESCRIPTION
Add limited support for I2C devices - specifically the PCA9685 controller

This does not fit in smoothly, since it has turned out that the abstractions created were not quite right. However, it does function for now